### PR TITLE
Refactor storyboard positioning

### DIFF
--- a/apps/editor-demo-app/src/app/app.tsx
+++ b/apps/editor-demo-app/src/app/app.tsx
@@ -7,14 +7,12 @@ import {
   selectSelection,
 } from '@joonasmkauppinen/store-zustand';
 
-const StyledApp = styled.div`
-  height: 100vh;
-  display: flex;
-  flex-direction: row;
-  background-color: red;
-`;
-
 const SamplePanel = styled.div({
+  zIndex: 100,
+  position: 'fixed',
+  top: 0,
+  right: 0,
+  bottom: 0,
   backgroundColor: '#2F3331',
   width: 250,
   minWidth: 250,
@@ -33,10 +31,10 @@ export const App = () => {
   const selection = useStore(selectSelection);
 
   return (
-    <StyledApp>
+    <>
       <LayersPanel actions={actions} cards={cards} selection={selection} />
       <Storyboard actions={actions} cards={cards} selection={selection} />
       <SamplePanel>Options panel coming soon.</SamplePanel>
-    </StyledApp>
+    </>
   );
 };

--- a/apps/editor-demo-app/src/index.html
+++ b/apps/editor-demo-app/src/index.html
@@ -18,6 +18,7 @@
         width: 100vw;
         height: 100vh;
         font-family: system-ui;
+        overflow: hidden;
       }
     </style>
   </head>

--- a/packages/storyboard-renderer/src/components/LayersPanel/LayerIcon/Icons/CardIcon.tsx
+++ b/packages/storyboard-renderer/src/components/LayersPanel/LayerIcon/Icons/CardIcon.tsx
@@ -8,8 +8,8 @@ export const CardIcon = () => (
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      fill-rule="evenodd"
-      clip-rule="evenodd"
+      fillRule="evenodd"
+      clipRule="evenodd"
       d="M3 2L3 0H11V2L13 2V12L11 12V14H3L3 12H1L1 2L3 2ZM4 1H10V13H4V1ZM3 3H2L2 11H3V3ZM11 11H12V3H11V11Z"
       fill="#A9ABAA"
     />

--- a/packages/storyboard-renderer/src/components/LayersPanel/LayerIcon/Icons/ImageIcon.tsx
+++ b/packages/storyboard-renderer/src/components/LayersPanel/LayerIcon/Icons/ImageIcon.tsx
@@ -8,14 +8,14 @@ export const ImageIcon = () => (
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      fill-rule="evenodd"
-      clip-rule="evenodd"
+      fillRule="evenodd"
+      clipRule="evenodd"
       d="M11 5C11 6.10457 10.1046 7 9 7C7.89543 7 7 6.10457 7 5C7 3.89543 7.89543 3 9 3C10.1046 3 11 3.89543 11 5ZM10 5C10 5.55228 9.55228 6 9 6C8.44772 6 8 5.55228 8 5C8 4.44772 8.44772 4 9 4C9.55228 4 10 4.44772 10 5Z"
       fill="#A9ABAA"
     />
     <path
-      fill-rule="evenodd"
-      clip-rule="evenodd"
+      fillRule="evenodd"
+      clipRule="evenodd"
       d="M1 13H13V1H1V13ZM5 6.09861L2 10.5986V2H12V12H8.93426L5 6.09861ZM5 7.90139L7.73241 12H2.26759L5 7.90139Z"
       fill="#A9ABAA"
     />

--- a/packages/storyboard-renderer/src/components/LayersPanel/LayersPanel.tsx
+++ b/packages/storyboard-renderer/src/components/LayersPanel/LayersPanel.tsx
@@ -8,6 +8,11 @@ import { PanelHeader } from './PanelHeader/PanelHeader';
 
 // TODO: Get style values from theme
 const StyledPanelSection = styled.section({
+  zIndex: 100,
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  bottom: 0,
   backgroundColor: '#2F3331',
   width: 300,
   minWidth: 300,

--- a/packages/storyboard-renderer/src/components/Storyboard/AddCardButton/AddCardButton.tsx
+++ b/packages/storyboard-renderer/src/components/Storyboard/AddCardButton/AddCardButton.tsx
@@ -6,6 +6,7 @@ import { PlusIcon } from './PlusIcon';
 
 const StyledButton = styled.button({
   all: 'unset',
+  alignSelf: 'center',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
@@ -19,7 +20,6 @@ const StyledButton = styled.button({
   borderRadius: 3,
   cursor: 'pointer',
   minWidth: 75,
-  marginRight: 300,
   ':hover': {
     backgroundColor: '#4A4D4A',
     transition: 'background-color 100ms',

--- a/packages/storyboard-renderer/src/components/Storyboard/AddCardButton/PlusIcon.tsx
+++ b/packages/storyboard-renderer/src/components/Storyboard/AddCardButton/PlusIcon.tsx
@@ -7,8 +7,8 @@ export const PlusIcon = () => (
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      fill-rule="evenodd"
-      clip-rule="evenodd"
+      fillRule="evenodd"
+      clipRule="evenodd"
       d="M7.5 9.5V17H9.5V9.5H17V7.5H9.5V0H7.5V7.5H0V9.5H7.5Z"
       fill="white"
     />

--- a/packages/storyboard-renderer/src/components/Storyboard/CardSection/CardItem/CardItem.tsx
+++ b/packages/storyboard-renderer/src/components/Storyboard/CardSection/CardItem/CardItem.tsx
@@ -10,6 +10,11 @@ import {
   Size,
 } from '@joonasmkauppinen/store-zustand';
 
+import {
+  CARD_ITEM_HEIGHT,
+  CARD_ITEM_WIDTH,
+} from '../../../../constants/dimensions';
+
 export interface CardItemProps
   extends LayerActionsProp,
     React.HTMLAttributes<HTMLDivElement> {
@@ -32,8 +37,8 @@ const setBoxShadowByState = (state: ElementState) => {
 
 const StyledCardItem = styled.div<{ state: ElementState }>(({ state }) => ({
   backgroundColor: 'white',
-  width: 360,
-  height: 640,
+  width: CARD_ITEM_WIDTH,
+  height: CARD_ITEM_HEIGHT,
   display: 'block',
   position: 'relative',
   borderRadius: 2,

--- a/packages/storyboard-renderer/src/components/Storyboard/CardSection/CardSection.tsx
+++ b/packages/storyboard-renderer/src/components/Storyboard/CardSection/CardSection.tsx
@@ -11,14 +11,19 @@ export interface CardItemProps extends LayerActionsProp {
 const Container = styled.div({
   display: 'flex',
   flexDirection: 'column',
-  marginLeft: 100,
   marginRight: 100,
+  position: 'relative',
 });
 
+// TODO: Don't use magical number for the positioning.
 const CardName = styled.p({
   color: 'white',
   size: 16,
+  margin: 0,
   userSelect: 'none',
+  position: 'absolute',
+  left: 0,
+  top: -30,
 });
 
 export const CardSection = ({ card, actions, cardId }: CardItemProps) => {

--- a/packages/storyboard-renderer/src/components/Storyboard/Storyboard.tsx
+++ b/packages/storyboard-renderer/src/components/Storyboard/Storyboard.tsx
@@ -8,6 +8,7 @@ import {
 import { CardSection } from './CardSection/CardSection';
 import { Selection } from '../Selection/Selection';
 import { AddCardButton } from './AddCardButton/AddCardButton';
+import { CARD_ITEM_HEIGHT, CARD_ITEM_WIDTH } from '../../constants/dimensions';
 
 export interface StoryboardProps extends LayerActionsProp {
   cards: Cards;
@@ -15,27 +16,48 @@ export interface StoryboardProps extends LayerActionsProp {
 }
 
 const StyledStoryboard = styled.div({
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  bottom: 0,
+  right: 0,
   backgroundColor: '#1B1D1C',
-  display: 'flex',
-  flex: 1,
-  flexDirection: 'row',
-  alignContent: 'center',
-  alignItems: 'center',
-  overflow: 'scroll',
+  overflow: 'auto',
 });
+
+const StyledStoryboardItemsContainerSection = styled.section({
+  display: 'flex',
+  flexDirection: 'row',
+  width: 'max-content',
+});
+
+const INITIAL_CLIENT_WIDTH = window.innerWidth;
+const INITIAL_CLIENT_HEIGHT = window.innerHeight;
+
+const PADDING_VERTICAL = INITIAL_CLIENT_HEIGHT / 2 - CARD_ITEM_HEIGHT / 2;
+const PADDING_HORIZONTAL = INITIAL_CLIENT_WIDTH / 2 - CARD_ITEM_WIDTH / 2;
 
 export const Storyboard = ({ cards, actions, selection }: StoryboardProps) => {
   return (
-    <StyledStoryboard>
-      {Object.entries(cards).map(([cardId, card]) => (
-        <CardSection
-          cardId={cardId}
-          key={`card-section-${cardId}`}
-          card={card}
-          actions={actions}
-        />
-      ))}
-      <AddCardButton onClick={() => actions.addNewCard()} />
+    <StyledStoryboard
+      style={{
+        paddingTop: PADDING_VERTICAL,
+        paddingBottom: PADDING_VERTICAL,
+        paddingLeft: PADDING_HORIZONTAL,
+        paddingRight: PADDING_HORIZONTAL,
+      }}
+    >
+      <StyledStoryboardItemsContainerSection>
+        {Object.entries(cards).map(([cardId, card]) => (
+          <CardSection
+            cardId={cardId}
+            key={`card-section-${cardId}`}
+            card={card}
+            actions={actions}
+          />
+        ))}
+        <AddCardButton onClick={() => actions.addNewCard()} />
+      </StyledStoryboardItemsContainerSection>
       <Selection cards={cards} actions={actions} selection={selection} />
     </StyledStoryboard>
   );

--- a/packages/storyboard-renderer/src/constants/dimensions.ts
+++ b/packages/storyboard-renderer/src/constants/dimensions.ts
@@ -1,0 +1,2 @@
+export const CARD_ITEM_HEIGHT = 640;
+export const CARD_ITEM_WIDTH = 360;


### PR DESCRIPTION
- closes #44 

Storyboard is now using position fixed to fill the entire screen. Cards are centered in the Storyboard by setting paddings to it. Paddings are calculated based on the client viewport size.

This might not be a sufficient way to handle positioning in the long run, but for now it's good enough.